### PR TITLE
Hotfix/precision rebased

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.dyne/freecoin-lib "0.9.2"  
+(defproject org.clojars.dyne/freecoin-lib "0.9.3-SNAPSHOT"  
   :description "Freecoin digital currency toolkit"
   :url "https://freecoin.dyne.org"
 

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [clojure-humanize "0.2.2"]
 
                  ;; storage
-                 [org.clojars.dyne/clj-storage "0.5.0"]
+                 [org.clojars.dyne/clj-storage "0.6.0-SNAPSHOT"]
 
                  ;; fxc secret sharing protocol
                  [org.clojars.dyne/fxc "0.5.0"]
@@ -30,7 +30,10 @@
                  [clj-btc "0.11.2"]
 
                  ;; error handling
-                 [failjure "1.2.0"]]
+                 [failjure "1.2.0"]
+
+                 ;; Use mongo bson data types like Decimal128
+                 [org.mongodb/mongodb-driver "3.6.0-beta2"]]
 
   :source-paths ["src"]
   :resource-paths ["resources" "test-resources"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.dyne/freecoin-lib "0.9.3-SNAPSHOT"  
+(defproject org.clojars.dyne/freecoin-lib "0.9.3"  
   :description "Freecoin digital currency toolkit"
   :url "https://freecoin.dyne.org"
 
@@ -15,7 +15,7 @@
                  [clojure-humanize "0.2.2"]
 
                  ;; storage
-                 [org.clojars.dyne/clj-storage "0.6.0-SNAPSHOT"]
+                 [org.clojars.dyne/clj-storage "0.5.1"]
 
                  ;; fxc secret sharing protocol
                  [org.clojars.dyne/fxc "0.5.0"]

--- a/src/freecoin_lib/core.clj
+++ b/src/freecoin_lib/core.clj
@@ -115,10 +115,7 @@ Used to identify the class type."
 
 (defn- normalize-transactions [list]
   (reverse
-   (sort-by :timestamp
-            (map (fn [{:keys [amount] :as transaction}]
-                   (assoc transaction :amount amount))
-                 list))))
+   (sort-by :timestamp list)))
 
 (defn merge-params [params f name updater]
   (if-let [request-value (params name)]
@@ -234,12 +231,11 @@ Used to identify the class type."
                                               :count {"$sum" 1}
                                               :amount {"$sum" "$amount"}}}])
           tags (storage/aggregate (:transaction-store stores-m)  params)]
-      (mapv (fn [{:keys [_id count amount amount-text]}]
+      (mapv (fn [{:keys [_id count amount]}]
               (let [tag (tag/fetch (:tag-store stores-m) _id)]
                 {:tag   _id
                  :count count
                  :amount amount
-                 :amount-text amount-text
                  :created-by (:created-by tag)
                  :created (:created tag)}))
             tags)))

--- a/src/freecoin_lib/db/confirmation.clj
+++ b/src/freecoin_lib/db/confirmation.clj
@@ -36,15 +36,13 @@
                        :type :transaction
                        :data {:sender-email sender-email
                               :recipient-email recipient-email
-                              :amount (util/bigdecimal->long amount)
+                              :amount amount
                               :tags tags}}
-         stored (some-> (storage/store! confirmation-store :uid confirmation)
-                        (update-in [:data :amount] util/long->bigdecimal))]
+         stored (some-> (storage/store! confirmation-store :uid confirmation))]
      stored)))
 
 (defn fetch [confirmation-store email]
-  (some-> (storage/fetch confirmation-store email)
-          (update-in [:data :amount] util/long->bigdecimal)))
+  (some-> (storage/fetch confirmation-store email)))
 
 (defn delete! [confirmation-store email]
   (storage/delete! confirmation-store email))

--- a/src/freecoin_lib/utils.clj
+++ b/src/freecoin_lib/utils.clj
@@ -105,14 +105,6 @@
                   positive-amount (positive-value? dec128-amount)]
                  positive-amount
                  (f/when-failed [e]
-                   (log/warn "Attempt to insert amount " amount)
-                   (f/fail (f/message e)))))
-
-(defn validate-big-decimal-amount [amount]
-  (f/attempt-all [dec128-amount (decimal128? amount)
-                  positive-amount (positive-value? dec128-amount)]
-                 positive-amount
-                 (f/when-failed [e]
-                   (log/warn "Attempt to create amount " amount)
+                   (log/warn "The amount is not a valid number." amount)
                    (f/fail (f/message e)))))
 

--- a/test/freecoin_lib/test/db/transaction.clj
+++ b/test/freecoin_lib/test/db/transaction.clj
@@ -42,24 +42,24 @@
                                                                      :to-id "B"
                                                                      :currency "mongo"
                                                                      ;; TODO add tags and test them
-                                                                     :amount (utils/bigdecimal->long 1)})
+                                                                     :amount 1})
 
                              (storage/store! transaction-store :id_ {:from-id "A"
                                                                      :to-id "C"
                                                                      :currency "mongo"
                                                                      ;; TODO add tags and test them
-                                                                     :amount (utils/bigdecimal->long 2)})
+                                                                     :amount 2})
 
                              (storage/store! transaction-store :id_ {:from-id "B"
                                                                      :to-id "C"
                                                                      :currency "mongo"
                                                                      ;; TODO add tags and test them
-                                                                     :amount (utils/bigdecimal->long 2)})
+                                                                     :amount 2})
                              (storage/store! transaction-store :id_ {:from-id "C"
                                                                      :to-id "A"
                                                                      :currency "faircoin"
                                                                      ;; TODO add tags and test them
-                                                                     :amount (utils/bigdecimal->long 20)})
+                                                                     :amount 20})
                              
                              (fact "The budget per account is correct"
                                    (let [mongo-bc (blockchain/new-mongo stores-m)]


### PR DESCRIPTION
This is part of the numerical precision fix on the SWAPI. Basic point is that we are now storing the amount in two fields: one using the Decimal128 Mongo high precision representation and as a backup a text-representation.
The faulty long->decimal and vice versa are not used in the SWAPI any longer and are deprecated. They are still used at the Macao Wallet.
@jaromil can you please have a sanity check?